### PR TITLE
Use the production url instead of the test one

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oxfam-trailwalker",
   "version": "0.1.0",
   "private": true,
-  "homepage": "https://rawgit.com/findmeawalk-ci/builds/switch-to-react/",
+  "homepage": "https://findmeawalk.com/",
   "devDependencies": {
     "custom-react-scripts": "0.0.23",
     "flow-bin": "^0.36.0",


### PR DESCRIPTION
This accidentally got left in while I was testing (and looked ok through the PR's) but should really be the production url, which will get swapped out by travis when a PR needs to be built.